### PR TITLE
Remove Prettier integration from ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,9 +13,7 @@
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:react-hooks/recommended",
-    "plugin:prettier/recommended",
-    "prettier"
+    "plugin:react-hooks/recommended"
   ],
   "overrides": [],
   "parser": "@typescript-eslint/parser",
@@ -47,7 +45,6 @@
     ],
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
-    "react/react-in-jsx-scope": "off",
-    "prettier/prettier": "error"
+    "react/react-in-jsx-scope": "off"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "husky": "^8.0.3",
-        "prettier": "3.0.3",
         "prettier-plugin-tailwindcss": "^0.5.4"
       }
     },
@@ -5770,6 +5769,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
       "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10920,7 +10920,6 @@
         "my-portfolio": "file:",
         "next": "^14.2.18",
         "postcss": "^8.4.30",
-        "prettier": "3.0.3",
         "prettier-plugin-tailwindcss": "^0.5.4",
         "prop-types": "^15.8.1",
         "react": "18.2.0",
@@ -14872,7 +14871,8 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
           "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "prettier-linter-helpers": {
           "version": "1.0.0",
@@ -16341,7 +16341,8 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
       "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^8.0.3",
-    "prettier": "3.0.3",
     "prettier-plugin-tailwindcss": "^0.5.4"
   },
   "config": {


### PR DESCRIPTION
Prettier and related ESLint plugins have been removed from .eslintrc.json and package.json. This simplifies the linting setup by decoupling Prettier from ESLint.